### PR TITLE
Bump version of github.com/aws/jsii-runtime-go

### DIFF
--- a/awscdk/go.mod
+++ b/awscdk/go.mod
@@ -3,6 +3,6 @@ module github.com/aws/aws-cdk-go/awscdk
 go 1.16
 
 require (
-	github.com/aws/jsii-runtime-go v1.27.0
+	github.com/aws/jsii-runtime-go v1.27.1
 	github.com/aws/constructs-go/constructs/v3 v3.3.71
 )


### PR DESCRIPTION

*Issue #, if available:* https://github.com/aws/jsii/pull/2786

*Description of changes:*

github.com/aws/jsii-runtime-go@v1.27.0 had some issues that caused dependency download failures, which were fixed in v1.27.1

```
go: github.com/aws/aws-cdk-go/awscdk@v1.98.0-devpreview requires
        github.com/aws/jsii-runtime-go@v1.27.0: verifying go.mod: checksum mismatch
        downloaded: h1:+9t6P1aXlPO0lXa8LtXGBUTcf5tbUekFFFQ4ewFIqAk=
        sum.golang.org: h1:9ddMDdGQwew6pQrfuTID/LxDDrpyrybwsWN84etzjQ8=
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
