### PR TITLE
Update README.md

### DIFF
--- a/awscdk/awsapigateway/README.md
+++ b/awscdk/awsapigateway/README.md
@@ -1134,8 +1134,8 @@ authorizer := awscdk.NewRequestAuthorizer(stack, jsii.String("MyAuthorizer"), &R
 secondAuthorizer := awscdk.NewRequestAuthorizer(stack, jsii.String("MySecondAuthorizer"), &RequestAuthorizerProps{
 	Handler: authorizerFn,
 	IdentitySources: []*string{
-		awscdk.IdentitySource_*Header(jsii.String("Authorization")),
-		awscdk.IdentitySource_*QueryString(jsii.String("allow")),
+		awscdk.IdentitySource_Header(jsii.String("Authorization")),
+		awscdk.IdentitySource_QueryString(jsii.String("allow")),
 	},
 })
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixing a typo in the documentation. There was an asterisk ("*") in the middle of two names:

```go
awscdk.IdentitySource_*Header(jsii.String("Authorization")),
awscdk.IdentitySource_*QueryString(jsii.String("allow")),
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
